### PR TITLE
Attach my security groups

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -8,6 +8,10 @@ Parameters:
     Description: The EC2 Key Pair to allow SSH access to the instances
     Type: AWS::EC2::KeyPair::KeyName
 
+  MySecurityGroups:
+    Description: Set you hope to add Secury Groups to the instances
+    Type: List<AWS::EC2::SecurityGroup::Id>
+
   NodeImageId:
     Description: AMI id for the node instances.
     Type: AWS::EC2::Image::Id
@@ -426,8 +430,11 @@ Resources:
       ImageId: !Ref NodeImageId
       InstanceType: !Ref NodeInstanceType
       KeyName: !Ref KeyName
-      SecurityGroups:
-        - !Ref NodeSecurityGroup
+      SecurityGroups: !Split
+        - ","
+        - !Sub
+          - "${MySecurityGroupidList},${NodeSecurityGroup}"
+          - MySecurityGroupidList: !Join [",",!Ref "MySecurityGroups"]
       BlockDeviceMappings:
         - DeviceName: /dev/xvda
           Ebs:

--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -9,7 +9,7 @@ Parameters:
     Type: AWS::EC2::KeyPair::KeyName
 
   MySecurityGroups:
-    Description: Set you hope to add Secury Groups to the instances
+    Description: Set you hope to add Security Groups to the instances
     Type: List<AWS::EC2::SecurityGroup::Id>
 
   NodeImageId:


### PR DESCRIPTION
- Cloud Fromation( =CF ) から自分のセキュリティグループ( =SG )を設定できるようにしました。
- EKS の Node は この yml を使って作成することを推奨しています
  - 参考: https://docs.aws.amazon.com/ja_jp/eks/latest/userguide/launch-workers.html
- この CF で起動設定、Auto Scaling の設定をやってくれます
  - 現状は 立ち上がった EC2 に対して必要な SG を手動で付与していますが、これだとオートスケールの際に問題になります。
  - EKSのために必要な SG しか付与されないので、 ALB とつながらない、SSH できないなどの問題が起きます。 
  - 起動設定を書き換えてもいいのですがそうなると、k8s のバージョンアップする際結構めんどくさくなります。
    - k8s のバージョンアップは AMI の更新になりますが、手動でやると、まずは起動設定でAMIで書き換え → 一台ずつ Draining → CAで新しい Node 立ち上がるのを待つ という感じでかなり面倒くさいです
  - CF を使って更新すると、なんと一台ずつインスタンスを落として、立ち上げてをやってくれます！なんと便利！
- そのため CF のテンプレートを更新するようにしました
- 参考: 
  -  https://docs.aws.amazon.com/ja_jp/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html
  -  https://bl.ocks.org/magnetikonline/a6cfc522a1e9f876b75962f5f553c8e5