### PR TITLE
Fix fs.inotify error

### DIFF
--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -256,7 +256,6 @@ Parameters:
   BootstrapArguments:
     Description: Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami
     Type: String
-    Default: ""
 
   NodeGroupName:
     Description: Unique identifier for the Node Group.
@@ -446,6 +445,7 @@ Resources:
           !Sub |
             #!/bin/bash
             set -o xtrace
+            sudo bash -lc "echo \"fs.inotify.max_user_watches = 524288\" >> /etc/sysctl.conf && sysctl -p"
             /etc/eks/bootstrap.sh ${ClusterName} ${BootstrapArguments}
             /opt/aws/bin/cfn-signal --exit-code $? \
                      --stack  ${AWS::StackName} \

--- a/amazon-eks-nodegroup.yaml
+++ b/amazon-eks-nodegroup.yaml
@@ -256,6 +256,7 @@ Parameters:
   BootstrapArguments:
     Description: Arguments to pass to the bootstrap script. See files/bootstrap.sh in https://github.com/awslabs/amazon-eks-ami
     Type: String
+    Default: ""
 
   NodeGroupName:
     Description: Unique identifier for the Node Group.


### PR DESCRIPTION
- Pod で `rails c` 出来ない問題を解決しました。
  - 解決策は、https://qiita.com/enta0701/items/bc9f8f8c780222979784 に書いてあるんですが、この方法だと Node 自体でやる必要があります。
  - なので、オートスケールするようになると上の解決策では対応できません
 - そこで  CF の UserData に inotify.max_user_watches を増やす処理を書きました。
   - こうすれば、インスタンスが立ち上がった際に設定してくれるので大丈夫なります
- テストクラスターで検証済みです
- deamonset でやる方法もありますが、どっちがいいでしょうか?
  - https://gist.github.com/brendan-rius/5ac9ec3dd7e196222c8b8b356f8973d2
